### PR TITLE
Upgrade ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "loader.js": "^4.0.1"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.3.0",
     "ember-cordova-installer": "^0.0.3"
   },
   "ember-addon": {


### PR DESCRIPTION
ember-cli-babel 5.x has been deprecated